### PR TITLE
Added custom responding page event

### DIFF
--- a/Sources/iPages/PageViewController+UIPageViewDelegate.swift
+++ b/Sources/iPages/PageViewController+UIPageViewDelegate.swift
@@ -12,9 +12,23 @@ import UIKit
 extension PageViewController {
     class Coordinator: NSObject, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
         var parent: PageViewController
+        var willTransitionTo: (_ pageViewController: UIPageViewController,
+                               _ pendingViewControllers: [UIViewController]) -> Void
+        var didFinishAnimating: (_ pageViewController: UIPageViewController,
+                                 _ didFinishAnimating: Bool,
+                                 _ previousViewControllers: [UIViewController],
+                                 _ transitionCompleted: Bool) -> Void
         
-        init(_ pageViewController: PageViewController) {
+        init(_ pageViewController: PageViewController,
+             willTransitionTo: @escaping (_ pageViewController: UIPageViewController,
+                                          _ pendingViewControllers: [UIViewController]) -> Void,
+             didFinishAnimating: @escaping (_ pageViewController: UIPageViewController,
+                                            _ didFinishAnimating: Bool,
+                                            _ previousViewControllers: [UIViewController],
+                                            _ transitionCompleted: Bool) -> Void) {
             self.parent = pageViewController
+            self.willTransitionTo = willTransitionTo
+            self.didFinishAnimating = didFinishAnimating
         }
         
         func pageViewController(
@@ -63,6 +77,14 @@ extension PageViewController {
             {
                 parent.currentPage = index
             }
+            self.didFinishAnimating(pageViewController, finished, previousViewControllers, completed)
+        }
+        
+        func pageViewController(
+            _ pageViewController: UIPageViewController,
+            willTransitionTo pendingViewControllers: [UIViewController])
+        {
+            self.willTransitionTo(pageViewController, pendingViewControllers)
         }
     }
 }

--- a/Sources/iPages/PageViewController.swift
+++ b/Sources/iPages/PageViewController.swift
@@ -22,12 +22,20 @@ struct PageViewController: ControllerRepresentable {
     var navigationOrientation: UIPageViewController.NavigationOrientation
     var bounce: Bool
     private var interPageSpacing: CGFloat = 0
+    
+    // delegate
+    var willTransitionTo: (_ pageViewController: UIPageViewController,
+                           _ pendingViewControllers: [UIViewController]) -> Void
+    var didFinishAnimating: (_ pageViewController: UIPageViewController,
+                             _ didFinishAnimating: Bool,
+                             _ previousViewControllers: [UIViewController],
+                             _ transitionCompleted: Bool) -> Void
     #endif
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(self)
+        Coordinator(self, willTransitionTo: willTransitionTo, didFinishAnimating: didFinishAnimating)
     }
-        
+    
     #if os(iOS)
     init(controllers: [ViewController],
          currentPage: Binding<Int>,
@@ -35,7 +43,13 @@ struct PageViewController: ControllerRepresentable {
          navigationOrientation: UIPageViewController.NavigationOrientation,
          bounce: Bool,
          interPageSpacing: CGFloat,
-         animated: Bool)
+         animated: Bool,
+         willTransitionTo: @escaping (_ pageViewController: UIPageViewController,
+                                      _ pendingViewControllers: [UIViewController]) -> Void = {_,_ in },
+         didFinishAnimating: @escaping (_ pageViewController: UIPageViewController,
+                                        _ didFinishAnimating: Bool,
+                                        _ previousViewControllers: [UIViewController],
+                                        _ transitionCompleted: Bool) -> Void = {_,_,_,_ in })
     {
         self.controllers = controllers
         self._currentPage = currentPage
@@ -44,6 +58,8 @@ struct PageViewController: ControllerRepresentable {
         self.bounce = bounce
         self.interPageSpacing = interPageSpacing
         self.animated = animated
+        self.willTransitionTo = willTransitionTo
+        self.didFinishAnimating = didFinishAnimating
     }
     
     func makeUIViewController(context: Context) -> UIPageViewController {

--- a/Sources/iPages/iPages+ViewModifiers.swift
+++ b/Sources/iPages/iPages+ViewModifiers.swift
@@ -14,6 +14,22 @@ import AppKit
 
 public extension iPages {
     
+    func willTransitionTo(_ delegate: @escaping (_ pageViewController: UIPageViewController,
+                                                 _ pendingViewControllers: [UIViewController]) -> Void) -> iPages {
+        var view = self
+        view.willTransitionTo = delegate
+        return view
+    }
+    
+    func didFinishAnimationg(_ delegate: @escaping (_ pageViewController: UIPageViewController,
+                                                    _ didFinishAnimating: Bool,
+                                                    _ previousViewControllers: [UIViewController],
+                                                    _ transitionCompleted: Bool) -> Void ) -> iPages {
+        var view = self
+        view.didFinishAnimating = delegate
+        return view
+    }
+    
     /// Modifies whether or not the page view should include the standard page control **dots**. (••••)
     /// - Parameter hideDots: Whether the page view should hide the page dots at the bottom 👇
     /// - Returns: A page view with the the desired presence or absence of dots
@@ -65,7 +81,7 @@ public extension iPages {
         view.pageControlPageIndicatorTintColor = otherPages
         return view
     }
-
+    
     /// Modifies the **background style** ⚪️🔘  of the page dots.
     /// - Parameter style: The style of the background of the page dots
     /// - Returns: A page view with the desired background style of the dots
@@ -75,7 +91,7 @@ public extension iPages {
         view.pageControlBackgroundStyle = style
         return view
     }
-        
+    
     /// Modifies the continuous interaction settings of the dots. 🔄
     /// - Parameter allowContinuousInteraction: Whether the dots allow continuous interaction
     /// - Returns: A page view with the desired continuous interaction settings of the page dots
@@ -86,7 +102,7 @@ public extension iPages {
         return view
     }
     #endif
-        
+    
     /// Modifies the **alignment of the page dots**. 👆 👇
     ///
     /// *Trailing* and *leading* alignments will cause the page dots to rotate vertical
@@ -97,7 +113,7 @@ public extension iPages {
         view.pageControlAlignment = alignment
         return view
     }
-        
+    
     #if os(iOS)
     /// Modifies the navigation **orientation** of the page view. ↔️ ↕️
     ///

--- a/Sources/iPages/iPages.swift
+++ b/Sources/iPages/iPages.swift
@@ -17,7 +17,15 @@ public struct iPages<Content: View>: View {
         hasExternalSelection ? $externalSelection : $internalSelection
     }
     private var hasExternalSelection = false
-        
+    
+    // delegate
+    var willTransitionTo: ((_ pageViewController: UIPageViewController,
+                            _ pendingViewControllers: [UIViewController]) -> Void) = {_,_ in}
+    var didFinishAnimating: ((_ pageViewController: UIPageViewController,
+                              _ didFinishAnimating: Bool,
+                              _ previousViewControllers: [UIViewController],
+                              _ transitionCompleted: Bool) -> Void) = {_,_,_,_ in }
+    
     // Page view controller
     var pageViewControllerWraps: Bool = false
     var pageViewAnimated: Bool = true
@@ -34,7 +42,9 @@ public struct iPages<Content: View>: View {
                      navigationOrientation: pageViewControllerNavigationOrientation,
                      bounce: pageViewControllerBounce,
                      interPageSpacing: pageViewControllerInterPageSpacing,
-                     animated: pageViewAnimated)
+                     animated: pageViewAnimated,
+                     willTransitionTo: willTransitionTo,
+                     didFinishAnimating: didFinishAnimating)
         #else
         return .init(controllers: viewControllers,
                      currentPage: selection)
@@ -110,9 +120,9 @@ public struct iPages<Content: View>: View {
             _externalSelection = Binding<Int>(get: { 0 }, set: { _ in })
         }
     }
-        
+    
     @Environment(\.layoutDirection) private var layoutDirection: LayoutDirection
-        
+    
     public var body: some View {
         ZStack(alignment: pageControlAlignment) {
             pageViewController


### PR DESCRIPTION
Added a way to customize `willTransitionTo` and `didFinishAnimationg` delegate method.
Please check it out and accept the request if you like it. 😆

example 
```swift
iPages {
    Text("iPages 🤑")
    Color.pink
}
.didFinishAnimationg { _, _, _, _ in
    print("Insert didFinishAnimating action code here")
}
.willTransitionTo { (pageViewController, viewControllers) in
    print("Insert willTransitionTo action code here")
}
```

It is implemented so that it is not expressed in "page view initializes" for readability when writing code.😀

![image](https://user-images.githubusercontent.com/45344633/124216267-d138b600-db30-11eb-935c-e9ac3ebf8f9f.png)
